### PR TITLE
Created endpoints for patientTransfers

### DIFF
--- a/backend/backend/fixtures/patient_transfers.json
+++ b/backend/backend/fixtures/patient_transfers.json
@@ -6,7 +6,7 @@
       "patient": 1,
       "transfer_date": "2024-11-01T10:00:00+01:00",
       "admission_date": "2024-11-01T10:30:00+01:00",
-      "discharge_date": "2024-11-15",
+      "discharge_date": "2025-11-15",
       "station_old": 2,
       "station_new": 1,
       "transferred_to_external": false
@@ -19,7 +19,7 @@
       "patient": 2,
       "transfer_date": "2024-11-05T09:15:00+01:00",
       "admission_date": "2024-11-05T09:45:00+01:00",
-      "discharge_date": "2024-11-20",
+      "discharge_date": "2025-11-20",
       "station_old": 1,
       "station_new": 2,
       "transferred_to_external": false
@@ -32,7 +32,7 @@
       "patient": 3,
       "transfer_date": "2024-11-10T14:20:00+01:00",
       "admission_date": "2024-11-10T14:45:00+01:00",
-      "discharge_date": "2024-11-25",
+      "discharge_date": "2025-11-25",
       "station_old": 2,
       "station_new": 3,
       "transferred_to_external": false
@@ -45,7 +45,7 @@
       "patient": 4,
       "transfer_date": "2024-11-12T08:00:00+01:00",
       "admission_date": "2024-11-12T08:15:00+01:00",
-      "discharge_date": "2024-11-18",
+      "discharge_date": "2025-11-18",
       "station_old": 1,
       "station_new": 4,
       "transferred_to_external": false
@@ -58,7 +58,7 @@
       "patient": 5,
       "transfer_date": "2024-11-15T12:30:00+01:00",
       "admission_date": "2024-11-15T13:00:00+01:00",
-      "discharge_date": "2024-11-28",
+      "discharge_date": "2025-11-28",
       "station_old": 2,
       "station_new": 5,
       "transferred_to_external": false
@@ -71,7 +71,7 @@
       "patient": 6,
       "transfer_date": "2024-11-01T15:45:00+01:00",
       "admission_date": "2024-11-01T16:00:00+01:00",
-      "discharge_date": "2024-11-10",
+      "discharge_date": "2025-11-10",
       "station_old": 3,
       "station_new": 6,
       "transferred_to_external": true
@@ -84,7 +84,7 @@
       "patient": 7,
       "transfer_date": "2024-11-08T10:20:00+01:00",
       "admission_date": "2024-11-08T10:45:00+01:00",
-      "discharge_date": "2024-11-22",
+      "discharge_date": "2025-11-22",
       "station_old": 4,
       "station_new": 7,
       "transferred_to_external": false
@@ -97,7 +97,7 @@
       "patient": 8,
       "transfer_date": "2024-11-03T08:50:00+01:00",
       "admission_date": "2024-11-03T09:15:00+01:00",
-      "discharge_date": "2024-11-12",
+      "discharge_date": "2025-11-12",
       "station_old": 5,
       "station_new": 8,
       "transferred_to_external": false
@@ -110,7 +110,7 @@
       "patient": 9,
       "transfer_date": "2024-11-17T14:00:00+01:00",
       "admission_date": "2024-11-17T14:30:00+01:00",
-      "discharge_date": "2024-11-29",
+      "discharge_date": "2025-11-29",
       "station_old": 6,
       "station_new": 9,
       "transferred_to_external": true
@@ -149,7 +149,7 @@
       "patient": 12,
       "transfer_date": "2024-11-18T07:15:00+01:00",
       "admission_date": "2024-11-18T07:45:00+01:00",
-      "discharge_date": "2024-11-26",
+      "discharge_date": "2025-11-26",
       "station_old": 9,
       "station_new": 3,
       "transferred_to_external": false
@@ -162,7 +162,7 @@
       "patient": 13,
       "transfer_date": "2024-11-05T12:20:00+01:00",
       "admission_date": "2024-11-05T12:50:00+01:00",
-      "discharge_date": "2024-11-15",
+      "discharge_date": "2025-11-15",
       "station_old": 7,
       "station_new": 4,
       "transferred_to_external": false
@@ -175,7 +175,7 @@
       "patient": 14,
       "transfer_date": "2024-11-09T08:30:00+01:00",
       "admission_date": "2024-11-09T09:00:00+01:00",
-      "discharge_date": "2024-11-21",
+      "discharge_date": "2025-11-21",
       "station_old": 1,
       "station_new": 5,
       "transferred_to_external": false
@@ -188,7 +188,7 @@
       "patient": 15,
       "transfer_date": "2024-11-12T14:00:00+01:00",
       "admission_date": "2024-11-12T14:30:00+01:00",
-      "discharge_date": "2024-11-23",
+      "discharge_date": "2025-11-23",
       "station_old": 2,
       "station_new": 6,
       "transferred_to_external": true

--- a/backend/backend/src/handle_patients.py
+++ b/backend/backend/src/handle_patients.py
@@ -19,7 +19,7 @@ def get_active_patients_on_station(station_id: int, date: datetime.date = dateti
     Returns:
         list: The patients assigned to the station.
     """
-   
+
     # Get the latest transfer_date for each patient
     latest_transfers = PatientTransfers.objects.filter(
         transfer_date__lte=date
@@ -71,7 +71,8 @@ def get_patients_with_additional_information(station_id: int) -> list:
                 station=station_id
             ).values("bed_number")
         )
-    ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '), F('patient__last_name')))
+    ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '), 
+                                                                   F('patient__last_name')))
 
     return list(patients)
 
@@ -105,12 +106,13 @@ def get_patient_count_per_station(station_id: int) -> int:
     Returns:
         int: The number of patients assigned to the station.
     """
-    
+
     return get_active_patients_on_station(station_id).count()
 
 
 def is_patient_new_to_station(patient_id: int, station_id: int) -> bool:
-    """Check if a patient was at station in the last three months. If yes, the 75 minutes are not added in care calculation.
+    """Check if a patient was at station in the last three months. 
+    If yes, the 75 minutes are not added in care calculation.
 
     Args:
         patient_id (int): The ID of the patient.
@@ -127,7 +129,7 @@ def is_patient_new_to_station(patient_id: int, station_id: int) -> bool:
         station_new_id=station_id,
         transfer_date__lte=today
     ).latest('transfer_date')
-    
+
     if today - latest_transfer_to_station > 90:
         return True
     else:
@@ -138,7 +140,7 @@ def visited_at_daytime(transfer_date: datetime.date, today: datetime.date) -> bo
     """Check if the patient's stay includes at least one day."""
     stay_duration = today - transfer_date
     return stay_duration.days >= 1
-    
+
 
 def visited_at_nighttime(transfer_date: datetime.date, today: datetime.date, now: datetime) -> bool:
     """Check if the patient's stay includes at least one night."""

--- a/backend/backend/src/handle_patients.py
+++ b/backend/backend/src/handle_patients.py
@@ -168,8 +168,8 @@ def get_patients_visit_type(station_id: int) -> dict:
     # Get all patients on station and initialize visit type lists
     all_patients = get_active_patients_on_station(station_id)
     stationary = []
-    partstationary = []
-    accute = []
+    part_stationary = []
+    acute = []
     undefined = []  # catch possible edges cases
 
     all_patients = get_active_patients_on_station(station_id)
@@ -182,16 +182,16 @@ def get_patients_visit_type(station_id: int) -> dict:
         if includes_day and includes_night:
             stationary.append(patient_transfer.patient)
         elif includes_day or includes_night:
-            partstationary.append(patient_transfer.patient)
+            part_stationary.append(patient_transfer.patient)
         elif not includes_night and includes_day:
-            accute.append(patient_transfer.patient)
+            acute.append(patient_transfer.patient)
         else:
             undefined.append(patient_transfer.patient)
 
     return {
         'stationary': stationary,
-        'partstationary': partstationary,
-        'accute': accute,
+        'part_stationary': part_stationary,
+        'acute': acute,
         'undefined': undefined
     }
 

--- a/backend/backend/src/handle_patients.py
+++ b/backend/backend/src/handle_patients.py
@@ -71,7 +71,7 @@ def get_patients_with_additional_information(station_id: int) -> list:
                 station=station_id
             ).values("bed_number")
         )
-    ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '), 
+    ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '),
                                                                    F('patient__last_name')))
 
     return list(patients)
@@ -111,7 +111,7 @@ def get_patient_count_per_station(station_id: int) -> int:
 
 
 def is_patient_new_to_station(patient_id: int, station_id: int) -> bool:
-    """Check if a patient was at station in the last three months. 
+    """Check if a patient was at station in the last three months.
     If yes, the 75 minutes are not added in care calculation.
 
     Args:

--- a/backend/backend/src/handle_patients.py
+++ b/backend/backend/src/handle_patients.py
@@ -1,10 +1,12 @@
 """Provide an endpoint to retrieve all current patients for a station."""
 import datetime
+from datetime import time
 
+from django.db.models import F, Max, OuterRef, Q, QuerySet, Subquery, Value
 from django.db.models.functions import Concat
 from django.http import JsonResponse
-from ..models import Patient, DailyClassification
-from django.db.models import Subquery, OuterRef, F, Value, QuerySet
+
+from ..models import DailyClassification, Patient, PatientTransfers
 
 
 def get_active_patients_on_station(station_id: int, date: datetime.date = datetime.date.today()) -> QuerySet[Patient]:
@@ -17,9 +19,23 @@ def get_active_patients_on_station(station_id: int, date: datetime.date = dateti
     Returns:
         list: The patients assigned to the station.
     """
-    patients = Patient.objects.all()
+   
+    # Get the latest transfer_date for each patient
+    latest_transfers = PatientTransfers.objects.filter(
+        transfer_date__lte=date
+    ).values('patient').annotate(
+        latest_transfer_date=Max('transfer_date')
+    )
 
-    return patients
+    # Filter the PatientTransfers based on the latest transfer_date and other conditions
+    active_patients = PatientTransfers.objects.filter(
+        Q(transfer_date__in=[lt['latest_transfer_date'] for lt in latest_transfers]),
+        station_new_id=station_id,
+        transferred_to_external=False,
+        discharge_date__gte=date
+    )
+
+    return active_patients
 
 
 def get_patients_with_additional_information(station_id: int) -> list:
@@ -41,7 +57,7 @@ def get_patients_with_additional_information(station_id: int) -> list:
     patients = patients.annotate(
         lastClassification=Subquery(
             DailyClassification.objects.filter(
-                patient=OuterRef('id'),
+                patient=OuterRef('patient_id'),
                 date__lte=today,
                 station=station_id
             )
@@ -50,14 +66,134 @@ def get_patients_with_additional_information(station_id: int) -> list:
         ),
         currentBed=Subquery(
             DailyClassification.objects.filter(
-                patient=OuterRef('id'),
+                patient=OuterRef('patient_id'),
                 date__lte=today,
                 station=station_id
             ).values("bed_number")
         )
-    ).values('id', 'lastClassification', "currentBed", name=Concat(F('first_name'), Value(' '), F('last_name')))
+    ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '), F('patient__last_name')))
 
     return list(patients)
+
+
+def get_current_station_for_patient(patient_id: int) -> int:
+    """Get the current station for a patient.
+
+    Args:
+        patient_id (int): The ID of the patient.
+
+    Returns:
+        int: The ID of the station the patient is currently assigned to.
+    """
+    today = datetime.date.today()
+
+    # Get the latest transfer_date for the patient
+    latest_transfer = PatientTransfers.objects.filter(
+        patient_id=patient_id,
+        transfer_date__lte=today
+    ).latest('transfer_date')
+
+    return latest_transfer.station_new_id
+
+
+def get_patient_count_per_station(station_id: int) -> int:
+    """Get the number of patients currently assigned to a station. Needed for night shift calculation.
+
+    Args:
+        station_id (int): The ID of the station.
+
+    Returns:
+        int: The number of patients assigned to the station.
+    """
+    
+    return get_active_patients_on_station(station_id).count()
+
+
+def is_patient_new_to_station(patient_id: int, station_id: int) -> bool:
+    """Check if a patient was at station in the last three months. If yes, the 75 minutes are not added in care calculation.
+
+    Args:
+        patient_id (int): The ID of the patient.
+        station_id (int): The ID of the station.
+
+    Returns:
+        bool: True if the patient is new to the station, False otherwise.
+    """
+    today = datetime.date.today()
+
+    # Get the latest transfer_date for the patient
+    latest_transfer_to_station = PatientTransfers.objects.filter(
+        patient_id=patient_id,
+        station_new_id=station_id,
+        transfer_date__lte=today
+    ).latest('transfer_date')
+    
+    if today - latest_transfer_to_station > 90:
+        return True
+    else:
+        return False
+
+
+def visited_at_daytime(transfer_date: datetime.date, today: datetime.date) -> bool:
+    """Check if the patient's stay includes at least one day."""
+    stay_duration = today - transfer_date
+    return stay_duration.days >= 1
+    
+
+def visited_at_nighttime(transfer_date: datetime.date, today: datetime.date, now: datetime) -> bool:
+    """Check if the patient's stay includes at least one night."""
+    night_start = time(22, 0)  # 10 PM
+    night_end = time(6, 0)  # 6 AM
+
+    if transfer_date == today:
+        if now.time() >= night_start or now.time() <= night_end:
+            return True
+    else:
+        return True
+    return False
+
+
+def get_patients_visit_type(station_id: int) -> dict:
+    """Return lists of patients for a single station classified by visit type.
+
+    Args:
+        station_id (int): The ID of the station.
+
+    Returns:
+        dict: A dictionary with lists of patients classified by visit type.
+    """
+    today = datetime.today().date()
+    now = datetime.now()
+
+    # Get all patients on station and initialize visit type lists
+    all_patients = get_active_patients_on_station(station_id)
+    stationary = []
+    partstationary = []
+    accute = []
+    undefined = []  # catch possible edges cases
+
+    all_patients = get_active_patients_on_station(station_id)
+    for patient_transfer in all_patients:
+        transfer_date = patient_transfer.transfer_date.date()
+        includes_day = visited_at_daytime(transfer_date, today)
+        includes_night = visited_at_nighttime(transfer_date, today, now)
+
+        # Check if stay includes day or night and classify patient
+        if includes_day and includes_night:
+            stationary.append(patient_transfer.patient)
+        elif includes_day or includes_night:
+            partstationary.append(patient_transfer.patient)
+        elif not includes_night and includes_day:
+            accute.append(patient_transfer.patient)
+        else:
+            undefined.append(patient_transfer.patient)
+
+    return {
+        'stationary': stationary,
+        'partstationary': partstationary,
+        'accute': accute,
+        'undefined': undefined
+    }
 
 
 def handle_patients(request, station_id: int) -> JsonResponse:

--- a/backend/backend/src/handle_stations.py
+++ b/backend/backend/src/handle_stations.py
@@ -1,10 +1,11 @@
 """Provide stations for the frontend to display  """
 from datetime import date
 
-from django.db.models import Subquery, OuterRef, Count, Value
+from django.db.models import Count, OuterRef, Subquery, Value
 from django.db.models.functions import Coalesce
 from django.http import JsonResponse
-from ..models import Station, PatientTransfers
+
+from ..models import PatientTransfers, Station
 
 
 def get_all_stations() -> list[Station]:
@@ -15,11 +16,17 @@ def get_all_stations() -> list[Station]:
     """
 
     today = date.today()
+    
+    # Subquery to get the latest transfer date for each patient
+    latest_transfer_date_subquery = PatientTransfers.objects.filter(
+        patient=OuterRef('patient')
+    ).order_by('-transfer_date').values('transfer_date')[:1]
 
-    # TODO fix this logic
     # Subquery to get the count of patients for each station
     patients_count_subquery = PatientTransfers.objects.filter(
         station_new_id=OuterRef('pk'),
+        transfer_date=Subquery(latest_transfer_date_subquery),
+        transferred_to_external=False,
         discharge_date__gte=today
     ).values('station_new_id').annotate(
         patient_count=Count('patient')
@@ -29,7 +36,6 @@ def get_all_stations() -> list[Station]:
     stations = Station.objects.annotate(
         patientCount=Coalesce(Subquery(patients_count_subquery), Value(0))
     ).values("id", "name", "patientCount")
-
     return list(stations)
 
 

--- a/backend/backend/src/handle_stations.py
+++ b/backend/backend/src/handle_stations.py
@@ -16,7 +16,7 @@ def get_all_stations() -> list[Station]:
     """
 
     today = date.today()
-    
+
     # Subquery to get the latest transfer date for each patient
     latest_transfer_date_subquery = PatientTransfers.objects.filter(
         patient=OuterRef('patient')


### PR DESCRIPTION
Closes #44 

Created following endpoints for patientTransfers in `handle_patients.py`
- get_current_station_for_patient
- get_patient_count_per_station
- is_patient_new_to_station (if not visited in last 90 days, the 75 minutes are added in care calculation)
- visited_at_daytime
- visited_at_nighttime
- get_patients_visit_type (for a station, return patient lists stationary, part_stationary, acute and undefined)


Fixed the endpoint for get_active_patients_on_station

Changed discharged dates in `patient_transfers.json` from past to future so that they are still present in hospital