### PR TITLE
Endpoints for patientTransfers (new)

### DIFF
--- a/backend/backend/fixtures/patient_transfers.json
+++ b/backend/backend/fixtures/patient_transfers.json
@@ -6,7 +6,7 @@
       "patient": 1,
       "transfer_date": "2024-11-01T10:00:00+01:00",
       "admission_date": "2024-11-01T10:30:00+01:00",
-      "discharge_date": "2024-11-15",
+      "discharge_date": "2025-11-15",
       "station_old": 2,
       "station_new": 1,
       "transferred_to_external": false
@@ -19,7 +19,7 @@
       "patient": 2,
       "transfer_date": "2024-11-05T09:15:00+01:00",
       "admission_date": "2024-11-05T09:45:00+01:00",
-      "discharge_date": "2024-11-20",
+      "discharge_date": "2025-11-20",
       "station_old": 1,
       "station_new": 2,
       "transferred_to_external": false
@@ -32,7 +32,7 @@
       "patient": 3,
       "transfer_date": "2024-11-10T14:20:00+01:00",
       "admission_date": "2024-11-10T14:45:00+01:00",
-      "discharge_date": "2024-11-25",
+      "discharge_date": "2025-11-25",
       "station_old": 2,
       "station_new": 3,
       "transferred_to_external": false
@@ -45,7 +45,7 @@
       "patient": 4,
       "transfer_date": "2024-11-12T08:00:00+01:00",
       "admission_date": "2024-11-12T08:15:00+01:00",
-      "discharge_date": "2024-11-18",
+      "discharge_date": "2025-11-18",
       "station_old": 1,
       "station_new": 4,
       "transferred_to_external": false
@@ -58,7 +58,7 @@
       "patient": 5,
       "transfer_date": "2024-11-15T12:30:00+01:00",
       "admission_date": "2024-11-15T13:00:00+01:00",
-      "discharge_date": "2024-11-28",
+      "discharge_date": "2025-11-28",
       "station_old": 2,
       "station_new": 5,
       "transferred_to_external": false
@@ -71,7 +71,7 @@
       "patient": 6,
       "transfer_date": "2024-11-01T15:45:00+01:00",
       "admission_date": "2024-11-01T16:00:00+01:00",
-      "discharge_date": "2024-11-10",
+      "discharge_date": "2025-11-10",
       "station_old": 3,
       "station_new": 6,
       "transferred_to_external": true
@@ -84,7 +84,7 @@
       "patient": 7,
       "transfer_date": "2024-11-08T10:20:00+01:00",
       "admission_date": "2024-11-08T10:45:00+01:00",
-      "discharge_date": "2024-11-22",
+      "discharge_date": "2025-11-22",
       "station_old": 4,
       "station_new": 7,
       "transferred_to_external": false
@@ -97,7 +97,7 @@
       "patient": 8,
       "transfer_date": "2024-11-03T08:50:00+01:00",
       "admission_date": "2024-11-03T09:15:00+01:00",
-      "discharge_date": "2024-11-12",
+      "discharge_date": "2025-11-12",
       "station_old": 5,
       "station_new": 8,
       "transferred_to_external": false
@@ -110,7 +110,7 @@
       "patient": 9,
       "transfer_date": "2024-11-17T14:00:00+01:00",
       "admission_date": "2024-11-17T14:30:00+01:00",
-      "discharge_date": "2024-11-29",
+      "discharge_date": "2025-11-29",
       "station_old": 6,
       "station_new": 9,
       "transferred_to_external": true
@@ -123,7 +123,7 @@
       "patient": 10,
       "transfer_date": "2024-11-06T11:00:00+01:00",
       "admission_date": "2024-11-06T11:30:00+01:00",
-      "discharge_date": "2024-11-16",
+      "discharge_date": "2025-11-16",
       "station_old": 7,
       "station_new": 1,
       "transferred_to_external": false
@@ -136,7 +136,7 @@
       "patient": 11,
       "transfer_date": "2024-11-10T09:40:00+01:00",
       "admission_date": "2024-11-10T10:00:00+01:00",
-      "discharge_date": "2024-11-20",
+      "discharge_date": "2025-11-20",
       "station_old": 8,
       "station_new": 2,
       "transferred_to_external": false
@@ -149,7 +149,7 @@
       "patient": 12,
       "transfer_date": "2024-11-18T07:15:00+01:00",
       "admission_date": "2024-11-18T07:45:00+01:00",
-      "discharge_date": "2024-11-26",
+      "discharge_date": "2025-11-26",
       "station_old": 9,
       "station_new": 3,
       "transferred_to_external": false
@@ -162,7 +162,7 @@
       "patient": 13,
       "transfer_date": "2024-11-05T12:20:00+01:00",
       "admission_date": "2024-11-05T12:50:00+01:00",
-      "discharge_date": "2024-11-15",
+      "discharge_date": "2025-11-15",
       "station_old": 7,
       "station_new": 4,
       "transferred_to_external": false
@@ -175,7 +175,7 @@
       "patient": 14,
       "transfer_date": "2024-11-09T08:30:00+01:00",
       "admission_date": "2024-11-09T09:00:00+01:00",
-      "discharge_date": "2024-11-21",
+      "discharge_date": "2025-11-21",
       "station_old": 1,
       "station_new": 5,
       "transferred_to_external": false
@@ -188,7 +188,7 @@
       "patient": 15,
       "transfer_date": "2024-11-12T14:00:00+01:00",
       "admission_date": "2024-11-12T14:30:00+01:00",
-      "discharge_date": "2024-11-23",
+      "discharge_date": "2025-11-23",
       "station_old": 2,
       "station_new": 6,
       "transferred_to_external": true

--- a/backend/backend/src/handle_calculations.py
+++ b/backend/backend/src/handle_calculations.py
@@ -1,10 +1,10 @@
 """Calculate the minutes each patient should receive care services."""
 from datetime import date
+
 from django.http import JsonResponse
 
+from ..models import DailyClassification, Patient, Station
 from .handle_questions import get_questions
-from ..models import (DailyClassification,
-                      Patient, Station)
 
 
 def group_and_count_data(data: list) -> dict:
@@ -205,7 +205,7 @@ def calculate_result(station_id, patient_id: int, date: date) -> dict:
         station=station,
         date=date,
     ).first()
-    print(classification)
+
     if classification is None:
         return {'error': 'No classification found for the specified date.'}
 

--- a/backend/backend/src/handle_patients.py
+++ b/backend/backend/src/handle_patients.py
@@ -74,7 +74,7 @@ def get_patients_with_additional_information(station_id: int) -> list:
         )
     ).values('id', 'lastClassification', "currentBed", name=Concat(F('patient__first_name'), Value(' '),
                                                                    F('patient__last_name')))
-    
+
     return list(patients)
 
 
@@ -235,7 +235,7 @@ def handle_visit_type(request, station_id: int) -> JsonResponse:
     else:
         return JsonResponse({'error': 'Method not allowed'}, status=405)
 
-    
+
 def handle_current_station_of_patient(request, patient_id: int) -> JsonResponse:
     """Endpoint to retrieve the current station of a patient.
 

--- a/backend/backend/src/handle_stations.py
+++ b/backend/backend/src/handle_stations.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 from django.db.models import Count, OuterRef, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, ExtractDay
 from django.http import JsonResponse
+from django.utils import timezone
 
 from ..models import PatientTransfers, Station, StationWorkloadDaily
 
@@ -18,7 +19,7 @@ def get_stations_analysis(frequency: str):
     """
     if frequency == "daily":
         # If 'daily', fetch the current day's data
-        today = datetime.now().date()
+        today = timezone.now().date()
         daily_workload = (
             StationWorkloadDaily.objects
             .filter(date=today)
@@ -38,7 +39,7 @@ def get_stations_analysis(frequency: str):
 
     elif frequency == "monthly":
         # Calculate the current month's date range
-        today = datetime.now()
+        today = timezone.now()
         start_date = today.replace(day=1)
         next_month = (today.replace(day=28) + timedelta(days=4)).replace(day=1)
         end_date = next_month - timedelta(days=1)
@@ -80,7 +81,7 @@ def get_all_stations() -> list:
     Returns:
         list: Stations.
     """
-    today = date.today()
+    today = timezone.now().date()
 
     # Subquery to get the latest transfer date for each patient
     latest_transfer_date_subquery = PatientTransfers.objects.filter(

--- a/backend/backend/src/handle_stations.py
+++ b/backend/backend/src/handle_stations.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta
+from datetime import timedelta
 
 from django.db.models import Count, OuterRef, Subquery, Sum, Value
 from django.db.models.functions import Coalesce, ExtractDay

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -20,6 +20,9 @@ urlpatterns = [
     path('stations/', handle_stations.handle_stations, name='handle_stations'),
     path('stations/analysis', handle_stations.handle_stations_analysis, name='stations-analysis'),
     path('visit-type/<int:station_id>/', handle_patients.handle_visit_type, name='handle_visit_type'),
-    path('current-station/<int:patient_id>/', handle_patients.handle_current_station_of_patient, 
-        name='handle_current_station_of_patient'),
+    path(
+        'current-station/<int:patient_id>/',
+        handle_patients.handle_current_station_of_patient,
+        name='handle_current_station_of_patient'
+    ),
 ]

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -1,7 +1,9 @@
 """This file contains the URL patterns for the API."""
 
 from django.urls import path
-from .src import handle_calculations, handle_questions, handle_patients, handle_stations
+
+from .src import (handle_calculations, handle_patients, handle_questions,
+                  handle_stations)
 
 urlpatterns = [
     path(
@@ -17,4 +19,6 @@ urlpatterns = [
     path('stations/<int:station_id>/', handle_patients.handle_patients, name='handle_patients'),
     path('stations/', handle_stations.handle_stations, name='handle_stations'),
     path('stations/analysis', handle_stations.handle_stations_analysis, name='stations-analysis'),
+    path('visit-type/<int:station_id>/', handle_patients.handle_visit_type, name='handle_visit_type'),
+    path('current-station/<int:patient_id>/', handle_patients.handle_current_station_of_patient, name='handle_current_station_of_patient'),
 ]

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -20,5 +20,6 @@ urlpatterns = [
     path('stations/', handle_stations.handle_stations, name='handle_stations'),
     path('stations/analysis', handle_stations.handle_stations_analysis, name='stations-analysis'),
     path('visit-type/<int:station_id>/', handle_patients.handle_visit_type, name='handle_visit_type'),
-    path('current-station/<int:patient_id>/', handle_patients.handle_current_station_of_patient, name='handle_current_station_of_patient'),
+    path('current-station/<int:patient_id>/', handle_patients.handle_current_station_of_patient, 
+        name='handle_current_station_of_patient'),
 ]


### PR DESCRIPTION
Closes #44 

Created following endpoints for patientTransfers in handle_patients.py

    get_current_station_for_patient
    get_patient_count_per_station
    is_patient_new_to_station (if not visited in last 90 days, the 75 minutes are added in care calculation)
    visited_at_daytime
    visited_at_nighttime
    get_patients_visit_type (for a station, return patient lists stationary, part_stationary, acute and undefined)

Fixed the endpoint for get_active_patients_on_station

Changed discharged dates in patient_transfers.json from past to future so that they are still present in hospital