### PR TITLE
Method and endpoint to directly add a classification

### DIFF
--- a/backend/backend/src/handle_calculations.py
+++ b/backend/backend/src/handle_calculations.py
@@ -1,11 +1,11 @@
 """Calculate the minutes each patient should receive care services."""
 from datetime import date, datetime
+
 from django.http import JsonResponse
 from django.utils import timezone
 
+from ..models import DailyClassification, DailyPatientData, Patient, Station
 from .handle_questions import get_questions
-from ..models import (DailyClassification,
-                      Patient, Station, DailyPatientData)
 
 
 def group_and_count_data(data: list) -> dict:
@@ -149,7 +149,7 @@ def sum_minutes(a_value: str, s_value: str, body: dict) -> int:
     # In case of a day of discharge, half the minutes_per_classification of the previous day are used (§ 12 (2)).
     # TODO: Issue
     minutes = 33  # Base value (§ 4 (2) 1. and  § 12 Absatz 1 Satz 1)
-    if body['is_in_isolation']:
+    if body.get("is_in_isolation", False):
         minutes = 123  # Base value for isolation (§ 4 (2) 2. and § 12 Absatz 1 Satz 2)
 
     # Data taken from the PPBV (§ 12 Absatz 4 Satz 1)
@@ -181,17 +181,25 @@ def sum_minutes(a_value: str, s_value: str, body: dict) -> int:
     }
     minutes += minutes_per_classification[f'A{a_value}'][f'S{s_value}']
 
-    if body['is_semi_stationary']:
+    if body.get("is_semi_stationary", False):
         minutes /= 2  # Only use half of the minutes (§ 4 (2) 3.)
 
     # § 4 (2) 3. and § 12 Absatz 3
-    if body['is_fully_stationary'] and body['is_day_of_admission']:
+    if body.get("is_fully_stationary", False) and body.get(
+        "is_day_of_admission", False
+    ):
         minutes += 75
-    if body['is_semi_stationary'] and not body['is_repeating_visit']:
+    if body.get("is_semi_stationary", False) and not body.get(
+        "is_repeating_visit", False
+    ):
         minutes += 75
 
     # Repeating visits due to same illness lead to less minutes for admission (§ 4 (2) 4. Satz 2)
-    if body['is_semi_stationary'] and body['is_repeating_visit'] and not body['has_entry_for_current_quarter']:
+    if (
+        body.get("is_semi_stationary", False)
+        and body.get("is_repeating_visit", False)
+        and not body.get("has_entry_for_current_quarter", False)
+    ):
         minutes += 75
 
     return minutes
@@ -297,6 +305,98 @@ def calculate_result(station_id: int, patient_id: int, date: date) -> dict:
     return {'minutes': minutes_to_take_care, 'category1': a_index, 'category2': s_index}
 
 
+def calculate_direct_classification(
+    station_id: int, patient_id: int, date: date, a_value: str, s_value: str
+):
+    """Calculate care minutes based on a_value and s_value alone.
+
+     Args:
+        station_id (int): The ID of the station.
+        patient_id (int): The ID of the patient.
+        date (date): The date of the classification.
+        a_value (str): The severity of the A group.
+        s_value (str): The severity of the S group.
+
+    Returns:
+        dict: The response containing the calculated minutes, the general and the specific care group.
+    """
+    patient = Patient.objects.get(id=patient_id)
+    station = Station.objects.get(id=station_id)
+
+    # Create "default" dailyClassification if it does not exist
+    classification = DailyClassification.objects.filter(
+        patient=patient,
+        station=station,
+        date=date,
+    ).first()
+
+    if classification is None:
+        classification = DailyClassification.objects.create(
+            patient=patient,
+            date=date,
+            is_in_isolation=False,
+            result_minutes=0,
+            a_index=0,
+            s_index=0,
+            station=station,
+            room_name="Test Raum",
+            bed_number=1,
+            barthel_index=0,
+            expanded_barthel_index=0,
+            mini_mental_status=0,
+        )
+
+    # If there is dailyPatientData, store information that influences the care minutes
+    direct_classification_data = {}
+
+    patient_data = (
+        DailyPatientData.objects.filter(
+            patient=patient,
+            station=station,
+            date=date,
+        )
+        .values()
+        .first()
+    )
+
+    if patient_data is not None:
+        direct_classification_data.update(patient_data)
+
+        datetime_date = datetime.strptime(date, "%Y-%m-%d").date()
+        direct_classification_data["is_day_of_admission"] = (
+            datetime_date == timezone.localtime(patient_data["day_of_admission"]).date()
+        )
+        direct_classification_data["is_day_of_discharge"] = (
+            datetime_date == timezone.localtime(patient_data["day_of_discharge"]).date()
+        )
+
+        if not direct_classification_data["uses_quarter_entry"]:
+            direct_classification_data["has_entry_for_current_quarter"] = (
+                has_entry_for_current_quarter(patient_id, date)
+            )
+            if (
+                direct_classification_data["is_semi_stationary"]
+                and direct_classification_data["is_repeating_visit"]
+                and not direct_classification_data["has_entry_for_current_quarter"]
+            ):
+                # The extra minutes will be used for the repeating visit
+                patient_data["is_repeating_visit"] = True
+        else:
+            # Use the quarter entry again for the calculation since it is already used for the patient on this day
+            direct_classification_data["has_entry_for_current_quarter"] = False
+
+    # Calculate the minutes accordingly
+    minutes_to_take_care = sum_minutes(a_value, s_value, direct_classification_data)
+
+    # Update dailyClassification
+    classification.result_minutes = minutes_to_take_care
+    classification.a_index = a_value
+    classification.s_index = s_value
+    classification.save()
+
+    return {"minutes": minutes_to_take_care, "category1": a_value, "category2": s_value}
+
+
 def handle_calculations(request, station_id, patient_id: int, date: date):
     """Endpoint to calculate the minutes a caregiver has time for caring for a patient.
 
@@ -313,3 +413,35 @@ def handle_calculations(request, station_id, patient_id: int, date: date):
         return JsonResponse(calculate_result(station_id, patient_id, date), status=200)
     else:
         return JsonResponse({'message': 'Method not allowed.'}, status=405)
+
+
+def handle_direct_classification(
+    request,
+    station_id: int,
+    patient_id: int,
+    date: date,
+    a_value: str,
+    s_value: str,
+):
+    """Endpoint to directly classify a patient.
+
+    Args:
+        request (HttpRequest): The request object.
+        station_id (int): The ID of the station.
+        patient_id (int): The ID of the patient.
+        date (str): The date of the classification ('YYYY-MM-DD').
+        a_value (str): The severity of the A group.
+        s_value (str): The severity of the S group.
+
+    Returns:
+        JsonResponse: The response containing the calculated minutes.
+    """
+    if request.method == "GET":
+        return JsonResponse(
+            calculate_direct_classification(
+                station_id, patient_id, date, a_value, s_value
+            ),
+            status=200,
+        )
+    else:
+        return JsonResponse({"message": "Method not allowed."}, status=405)

--- a/backend/backend/src/handle_questions.py
+++ b/backend/backend/src/handle_questions.py
@@ -1,12 +1,19 @@
 """Provide questions for the frontend to display and handle the submission of answers."""
-import json
+
 import datetime as datetime
+import json
 from collections import defaultdict
 
 from django.http import JsonResponse
 
-from ..models import (CareServiceOption, DailyClassification,
-                      IsCareServiceUsed, Patient, Station, DailyPatientData)
+from ..models import (
+    CareServiceOption,
+    DailyClassification,
+    DailyPatientData,
+    IsCareServiceUsed,
+    Patient,
+    Station,
+)
 
 
 def add_selected_attribute(care_service_options: list, classification: dict) -> list:
@@ -185,11 +192,10 @@ def submit_selected_options(station_id: int, patient_id: int, date: datetime.dat
     Returns:
         JsonResponse: The response containing the calculated minutes, the general and the specific care group.
     """
-    # Create the classification entry if it does not exist
     patient = Patient.objects.get(id=patient_id)
     station = Station.objects.get(id=station_id)
 
-    # Check if the classification already exists
+    # Create "default" dailyClassification if it does not exist
     classification = DailyClassification.objects.filter(
         patient=patient,
         date=date,

--- a/backend/backend/urls.py
+++ b/backend/backend/urls.py
@@ -2,42 +2,64 @@
 
 from django.urls import path
 
-from .src import (handle_calculations, handle_patients, handle_questions,
-                  handle_stations, handle_data_imports)
+from .src import (
+    handle_calculations,
+    handle_data_imports,
+    handle_patients,
+    handle_questions,
+    handle_stations,
+)
 
 urlpatterns = [
     path(
-        'questions/<int:station_id>/<int:patient_id>/<str:date>/',
+        "questions/<int:station_id>/<int:patient_id>/<str:date>/",
         handle_questions.handle_questions,
-        name='handle_questions'
+        name="handle_questions",
     ),
     path(
-        'calculate/<int:station_id>/<int:patient_id>/<str:date>/',
+        "calculate/<int:station_id>/<int:patient_id>/<str:date>/",
         handle_calculations.handle_calculations,
-        name='handle_calculations'
+        name="handle_calculations",
     ),
-    path('stations/<int:station_id>/', handle_patients.handle_patients, name='handle_patients'),
-    path('stations/', handle_stations.handle_stations, name='handle_stations'),
-    path('stations/analysis', handle_stations.handle_stations_analysis, name='stations-analysis'),
-    path('visit-type/<int:station_id>/', handle_patients.handle_visit_type, name='handle_visit_type'),
     path(
-        'current-station/<int:patient_id>/',
+        "stations/<int:station_id>/",
+        handle_patients.handle_patients,
+        name="handle_patients",
+    ),
+    path("stations/", handle_stations.handle_stations, name="handle_stations"),
+    path(
+        "stations/analysis",
+        handle_stations.handle_stations_analysis,
+        name="stations-analysis",
+    ),
+    path(
+        "visit-type/<int:station_id>/",
+        handle_patients.handle_visit_type,
+        name="handle_visit_type",
+    ),
+    path(
+        "current-station/<int:patient_id>/",
         handle_patients.handle_current_station_of_patient,
-        name='handle_current_station_of_patient'
+        name="handle_current_station_of_patient",
     ),
     path(
-        'import/patient/<str:date>/',
+        "import/patient/<str:date>/",
         handle_data_imports.handle_patient_data_import,
-        name='handle_patient_data_import'
+        name="handle_patient_data_import",
     ),
     path(
-        'import/caregiver/',
+        "import/caregiver/",
         handle_data_imports.handle_caregiver_shift_import,
-        name='handle_caregiver_shift_import'
+        name="handle_caregiver_shift_import",
     ),
     path(
-        'patient/dates/<int:patient_id>/<int:station_id>/',
+        "patient/dates/<int:patient_id>/<int:station_id>/",
         handle_patients.handle_patient_dates,
-        name='handle_patient_dates'
+        name="handle_patient_dates",
+    ),
+    path(
+        "calculate_direct/<int:station_id>/<int:patient_id>/<str:date>/<str:a_value>/<str:s_value>/",
+        handle_calculations.handle_direct_classification,
+        name="handle_direct_calculations",
     ),
 ]


### PR DESCRIPTION
- added method `calculate_direct_classification` to directly calculate care minutes based on a_value and s_value alone. Also consider information in DailyPatientData for calculation.
- created endpoint `handle_direct_classification` that calls the before mentioned method. Path format is "calculate_direct/<int:station_id>/<int:patient_id>/<str:date>/<str:a_value>/<str:s_value>/"
- updated all if statements in `sum_minutes` to body.get. This is in order to avoid key errors in case DailyPatientData is empty
